### PR TITLE
use the message sent date instead of the received one

### DIFF
--- a/daemon/historydaemon.cpp
+++ b/daemon/historydaemon.cpp
@@ -1122,7 +1122,7 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
     event[History::FieldThreadId] = threadId;
     event[History::FieldEventId] = eventId;
     event[History::FieldSenderId] = senderId;
-    event[History::FieldTimestamp] = message.received().toString("yyyy-MM-ddTHH:mm:ss.zzz");
+    event[History::FieldTimestamp] = message.sent().toString("yyyy-MM-ddTHH:mm:ss.zzz");
     event[History::FieldNewEvent] = true; // message is always unread until it reaches HistoryDaemon::onMessageRead
     event[History::FieldMessage] = message.text();
     event[History::FieldMessageType] = (int)type;

--- a/tests/common/mock/textchannel.cpp
+++ b/tests/common/mock/textchannel.cpp
@@ -165,7 +165,8 @@ void MockTextChannel::messageReceived(const QString &message, const QVariantMap 
 
     Tp::MessagePart header;
     header["message-token"] = QDBusVariant(info["SentTime"].toString() +"-" + QString::number(mMessageCounter++));
-    header["message-received"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
+    header["message-received"] = QDBusVariant(QDateTime::currentDateTime().toTime_t());
+    header["message-sent"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
     header["message-sender"] = QDBusVariant(mTargetHandle);
     header["message-sender-id"] = QDBusVariant(mRecipients.first());
     header["message-type"] = QDBusVariant(Tp::ChannelTextMessageTypeNormal);


### PR DESCRIPTION
Following issue https://github.com/ubports/messaging-app/issues/179 , this PR simply use message sent date instead of the received one