### PR TITLE
add exclusion filter

### DIFF
--- a/Ubuntu/History/historymodel.h
+++ b/Ubuntu/History/historymodel.h
@@ -72,7 +72,8 @@ public:
         MatchCaseSensitive = History::MatchCaseSensitive,
         MatchCaseInsensitive = History::MatchCaseInsensitive,
         MatchContains = History::MatchContains,
-        MatchPhoneNumber = History::MatchPhoneNumber
+        MatchPhoneNumber = History::MatchPhoneNumber,
+        MatchNotEquals = History::MatchNotEquals
     };
 
     enum MessageStatus

--- a/Ubuntu/History/historyqmlfilter.h
+++ b/Ubuntu/History/historyqmlfilter.h
@@ -39,7 +39,8 @@ public:
         MatchCaseSensitive = History::MatchCaseSensitive,
         MatchCaseInsensitive = History::MatchCaseInsensitive,
         MatchContains = History::MatchContains,
-        MatchPhoneNumber = History::MatchPhoneNumber
+        MatchPhoneNumber = History::MatchPhoneNumber,
+        MatchNotEquals = History::MatchNotEquals
     };
 
     explicit HistoryQmlFilter(QObject *parent = 0);

--- a/plugins/sqlite/sqlitehistoryplugin.cpp
+++ b/plugins/sqlite/sqlitehistoryplugin.cpp
@@ -1542,6 +1542,9 @@ QString SQLiteHistoryPlugin::filterToString(const History::Filter &filter, QVari
         if (filter.matchFlags() & History::MatchContains) {
             // FIXME: maybe we should use QString("%1 LIKE '\%'||%2'\%'").arg(bindId) ?? needs more time for investigating
             result = QString("%1 LIKE '\%%2\%' ESCAPE '\\'").arg(propertyName, escapeFilterValue(filterValue.toString()));
+        } else if (filter.matchFlags() & History::MatchNotEquals) {
+            result = QString("%1!=%2").arg(propertyName, bindId);
+            bindValues[bindId] = filterValue;
         } else {
             result = QString("%1=%2").arg(propertyName, bindId);
             bindValues[bindId] = filterValue;

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -76,7 +76,13 @@ QString FilterPrivate::toString(const QString &propertyPrefix) const
 
     QString propertyName = propertyPrefix.isNull() ? filterProperty : QString("%1.%2").arg(propertyPrefix, filterProperty);
     // FIXME2: need to check for the match flags
-    return QString("%1=%2").arg(propertyName, value);
+    QString condition;
+    if (matchFlags & History::MatchNotEquals) {
+        condition = QString("%1!=%2");
+    } else {
+        condition = QString("%1=%2");
+    }
+    return QString(condition).arg(propertyName, value);
 }
 
 bool FilterPrivate::match(const QVariantMap properties) const
@@ -87,7 +93,11 @@ bool FilterPrivate::match(const QVariantMap properties) const
     }
 
     // FIXME: use the MatchFlags
-    return properties[filterProperty] == filterValue;
+    if (matchFlags & History::MatchNotEquals) {
+        return properties[filterProperty] != filterValue;
+    } else {
+        return properties[filterProperty] == filterValue;
+    }
 }
 
 QVariantMap FilterPrivate::properties() const

--- a/src/types.h
+++ b/src/types.h
@@ -51,7 +51,8 @@ enum MatchFlag {
     MatchCaseSensitive = 0x01,
     MatchCaseInsensitive = 0x02,
     MatchContains = 0x04,
-    MatchPhoneNumber = 0x08
+    MatchPhoneNumber = 0x08,
+    MatchNotEquals = 0x10
 };
 
 Q_DECLARE_FLAGS(MatchFlags, MatchFlag)

--- a/tests/libhistoryservice/FilterTest.cpp
+++ b/tests/libhistoryservice/FilterTest.cpp
@@ -39,6 +39,7 @@ private Q_SLOTS:
     void testSetProperties();
     void testToString_data();
     void testToString();
+    void testToStringWithNotEqualsMatch();
     void testToStringPrefix();
     void testNullToString();
     void testMatch_data();
@@ -142,6 +143,15 @@ void FilterTest::testToString()
     QCOMPARE(filter.toString(), result);
 }
 
+void FilterTest::testToStringWithNotEqualsMatch()
+{
+    QString filterProperty("someProperty");
+    QString filterValue("someValue");
+
+    History::Filter filter(filterProperty, filterValue, History::MatchNotEquals);
+    QCOMPARE(filter.toString(),QString("%1!=\"%2\"").arg(filterProperty,filterValue));
+}
+
 void FilterTest::testToStringPrefix()
 {
     QString prefix("somePrefix");
@@ -215,12 +225,15 @@ void FilterTest::testMatchFlags_data()
     MatchCaseSensitive = 0x01,
     MatchCaseInsensitive = 0x02,
     MatchContains = 0x04,
-    MatchPhoneNumber = 0x08
+    MatchPhoneNumber = 0x08,
+    MatchNotEquals = 0x16
+
     */
     QTest::newRow("null flag") << History::MatchFlags() << History::MatchCaseSensitive << false;
     QTest::newRow("case sensitive alone") << History::MatchFlags(History::MatchCaseSensitive) << History::MatchCaseSensitive << true;
     QTest::newRow("case insensitive alone") << History::MatchFlags(History::MatchCaseInsensitive) << History::MatchCaseInsensitive << true;
     QTest::newRow("contains alone") << History::MatchFlags(History::MatchContains) << History::MatchContains << true;
+    QTest::newRow("not contains alone") << History::MatchFlags(History::MatchNotEquals) << History::MatchNotEquals << true;
     QTest::newRow("phone number alone") << History::MatchFlags(History::MatchPhoneNumber) << History::MatchPhoneNumber << true;
     QTest::newRow("no mismatch") << History::MatchFlags(History::MatchPhoneNumber) << History::MatchContains << false;
     QTest::newRow("all still match one") << History::MatchFlags(History::MatchCaseInsensitive |

--- a/tests/plugins/sqlite/SqlitePluginTest.cpp
+++ b/tests/plugins/sqlite/SqlitePluginTest.cpp
@@ -742,6 +742,11 @@ void SqlitePluginTest::testFilterToString_data()
     filterValues[":filterValue0"] = filter.filterValue();
     QTest::newRow("filter with a prefix") << filter.properties() << filterValues << QString("prefix") << "prefix.testProperty=:filterValue0";
 
+    filter.setFilterValue(12345);
+    filter.setMatchFlags(History::MatchNotEquals);
+    filterValues[":filterValue0"] = filter.filterValue();
+    QTest::newRow("filter not equals") << filter.properties() << filterValues << QString() << "testProperty!=:filterValue0";
+
     filter.setMatchFlags(History::MatchContains);
     filter.setFilterValue("partialString");
     filterValues.clear();


### PR DESCRIPTION
Currently, only Equals statements is allowed in History db filters. The idea here is to allow to add a "Not Equals" to the matchFlags criteria.
e.g give me all messages for account "ofono/ofono/account0" except the draft one
```
HistoryIntersectionFilter {
    HistoryFilter {
        filterProperty: "accountId"
        filterValue: "ofono/ofono/account0"
    }
    HistoryFilter {
        filterProperty: "messageStatus"
        filterValue: HistoryEventModel.MessageStatusDraft
	matchFlags: HistoryFilter.MatchNotEquals
    }
}
```

