### PR TITLE
 Revert "use the message sent date instead of the received one"

### DIFF
--- a/daemon/historydaemon.cpp
+++ b/daemon/historydaemon.cpp
@@ -1122,7 +1122,7 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
     event[History::FieldThreadId] = threadId;
     event[History::FieldEventId] = eventId;
     event[History::FieldSenderId] = senderId;
-    event[History::FieldTimestamp] = message.sent().toString("yyyy-MM-ddTHH:mm:ss.zzz");
+    event[History::FieldTimestamp] = message.received().toString("yyyy-MM-ddTHH:mm:ss.zzz");
     event[History::FieldNewEvent] = true; // message is always unread until it reaches HistoryDaemon::onMessageRead
     event[History::FieldMessage] = message.text();
     event[History::FieldMessageType] = (int)type;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+history-service (0.3~0ubports4) xenial; urgency=medium
+
+  * Revert use of sent date instead of the received one
+
+ -- Lionel Duboeuf <lduboeuf@ouvaton.org>  Tue, 09 Jul 2020 20:44:04 +0200
+
 history-service (0.3~0ubports3) xenial; urgency=medium
 
   * Allow querying history db with NotEquals match flag

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,6 @@ override_dh_install:
 
 override_dh_auto_test:
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
-    #CTEST_OUTPUT_ON_FAILURE=1 make -C obj-$(DEB_HOST_GNU_TYPE) test
-    cd obj-$(DEB_HOST_GNU_TYPE); ctest
+	#CTEST_OUTPUT_ON_FAILURE=1 make -C obj-$(DEB_HOST_GNU_TYPE) test
+	cd obj-$(DEB_HOST_GNU_TYPE); ctest
 endif

--- a/debian/rules
+++ b/debian/rules
@@ -12,5 +12,6 @@ override_dh_install:
 
 override_dh_auto_test:
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
-	CTEST_OUTPUT_ON_FAILURE=1 make -C obj-$(DEB_HOST_GNU_TYPE) test
+    #CTEST_OUTPUT_ON_FAILURE=1 make -C obj-$(DEB_HOST_GNU_TYPE) test
+    cd obj-$(DEB_HOST_GNU_TYPE); ctest
 endif


### PR DESCRIPTION
As users report issues with the send date, lets revert it now until we found a better solution.
see https://gitlab.com/ubports/community-ports/pinephone/-/issues/165