### PR TITLE
 Clean up code to build with -Wall -Werror -Wextra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ enable_testing()
 
 add_definitions(-std=c++11)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Werror -Wextra")
+# TODO remove the need for -Wno-unused-variable
+# unused-variable currently fails because of public headers includes static char's
+# there is also a gcc bug that makes it not possable to rely on diagnostic pragmas
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69967
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra -Wno-unused-variable")
+
 # Define the version to be used in the library
 set(HISTORY_VERSION_MAJOR 0)
 set(HISTORY_VERSION_MINOR 0)
@@ -107,5 +114,3 @@ IF(CMAKE_BUILD_TYPE MATCHES [cC][oO][vV][eE][rR][aA][gG][eE])
   GET_DIRECTORY_PROPERTY(COVERAGE_TARGETS DIRECTORY ${CMAKE_SOURCE_DIR} COVERAGE_TARGETS)
   ENABLE_COVERAGE_REPORT(TARGETS ${COVERAGE_TARGETS})
 ENDIF(CMAKE_BUILD_TYPE MATCHES [cC][oO][vV][eE][rR][aA][gG][eE])
-
-

--- a/Ubuntu/History/historyeventmodel.cpp
+++ b/Ubuntu/History/historyeventmodel.cpp
@@ -86,6 +86,9 @@ QVariant HistoryEventModel::eventData(const History::Event &event, int role) con
     case History::EventTypeVoice:
         voiceEvent = event;
         break;
+    case History::EventTypeNull:
+        qWarning("HistoryEventModel::eventData: Got EventTypeNull, ignoring this event!");
+        break;
     }
 
     QVariant result;

--- a/Ubuntu/History/historymodel.cpp
+++ b/Ubuntu/History/historymodel.cpp
@@ -59,7 +59,7 @@ HistoryModel::HistoryModel(QObject *parent) :
     triggerQueryUpdate();
 }
 
-bool HistoryModel::canFetchMore(const QModelIndex &parent) const
+bool HistoryModel::canFetchMore(const QModelIndex& /* parent */) const
 {
     return false;
 }
@@ -526,6 +526,9 @@ bool HistoryModel::markEventAsRead(const QVariantMap &eventProperties)
         break;
     case History::EventTypeVoice:
         event = History::VoiceEvent::fromProperties(eventProperties);
+        break;
+    case History::EventTypeNull:
+        qWarning("HistoryModel::markEventAsRead: Got EventTypeNull, ignoring this event!");
         break;
     }
 

--- a/Ubuntu/History/historymodel.h
+++ b/Ubuntu/History/historymodel.h
@@ -214,13 +214,13 @@ protected:
     bool mMatchContacts;
 
 private:
-    QHash<int, QByteArray> mRoles;
     History::Events mEventWritingQueue;
-    int mEventWritingTimer;
-    History::Threads mThreadWritingQueue;
-    int mThreadWritingTimer;
     int mUpdateTimer;
+    int mEventWritingTimer;
+    int mThreadWritingTimer;
     bool mWaitingForQml;
+    History::Threads mThreadWritingQueue;
+    QHash<int, QByteArray> mRoles;
 };
 
 #endif // HISTORYMODEL_H

--- a/Ubuntu/History/historythreadmodel.cpp
+++ b/Ubuntu/History/historythreadmodel.cpp
@@ -97,6 +97,9 @@ QVariant HistoryThreadModel::threadData(const History::Thread &thread, int role)
         case History::EventTypeVoice:
             voiceEvent = event;
             break;
+        case History::EventTypeNull:
+            qWarning("HistoryThreadModel::threadData: Got EventTypeNull, ignoring this event!");
+            break;
         }
     }
 

--- a/daemon/callchannelobserver.cpp
+++ b/daemon/callchannelobserver.cpp
@@ -68,6 +68,7 @@ void CallChannelObserver::onCallStateChanged(Tp::CallState state)
     }
     case Tp::CallStateActive:
         channel->setProperty("activeTimestamp", QDateTime::currentDateTime());
+        // fall through
     default:
         mCallStates[channel] = state;
         break;

--- a/daemon/historydaemon.cpp
+++ b/daemon/historydaemon.cpp
@@ -439,7 +439,7 @@ bool HistoryDaemon::writeEvents(const QList<QVariantMap> &events, const QVariant
 
     Q_FOREACH(const QVariantMap &event, events) {
         History::EventType type = (History::EventType) event[History::FieldType].toInt();
-        History::EventWriteResult result;
+        History::EventWriteResult result = History::EventWriteNone;
 
         // get the threads for the events to notify their modifications
         QString accountId = event[History::FieldAccountId].toString();
@@ -456,7 +456,7 @@ bool HistoryDaemon::writeEvents(const QList<QVariantMap> &events, const QVariant
             break;
         case History::EventTypeNull:
             qWarning("HistoryDaemon::writeEvents: Got EventTypeNull, ignoring this event!");
-            break;
+            continue;
         }
 
         // only get the thread AFTER the event is written to make sure it is up-to-date
@@ -481,6 +481,8 @@ bool HistoryDaemon::writeEvents(const QList<QVariantMap> &events, const QVariant
         case History::EventWriteError:
             mBackend->rollbackBatchOperation();
             return false;
+        case History::EventWriteNone:
+            break;
         }
     }
 
@@ -656,7 +658,7 @@ void HistoryDaemon::onCallEnded(const Tp::CallChannelPtr &channel, bool missed)
 
     // FIXME: check if checking for isRequested() is enough
     bool incoming = !channel->isRequested();
-    int duration;
+    int duration = 0;
 
     if (!missed) {
         QDateTime activeTime = channel->property("activeTimestamp").toDateTime();
@@ -1369,7 +1371,7 @@ void HistoryDaemon::writeRolesInformationEvents(const QVariantMap &thread, const
 
 History::MessageStatus HistoryDaemon::fromTelepathyDeliveryStatus(Tp::DeliveryStatus deliveryStatus)
 {
-    History::MessageStatus status;
+    History::MessageStatus status = History::MessageStatusUnknown;
     switch (deliveryStatus) {
     case Tp::DeliveryStatusAccepted:
         status = History::MessageStatusAccepted;
@@ -1402,7 +1404,7 @@ History::MessageStatus HistoryDaemon::fromTelepathyDeliveryStatus(Tp::DeliverySt
 
 History::ChatType HistoryDaemon::fromTelepathyHandleType(const Tp::HandleType &type)
 {
-    History::ChatType chatType;
+    History::ChatType chatType = History::ChatTypeNone;
     switch(type) {
     case Tp::HandleTypeContact:
         chatType = History::ChatTypeContact;

--- a/daemon/textchannelobserver.cpp
+++ b/daemon/textchannelobserver.cpp
@@ -66,7 +66,7 @@ void TextChannelObserver::onMessageReceived(const Tp::ReceivedMessage &message)
     Q_EMIT messageReceived(textChannel, message);
 }
 
-void TextChannelObserver::onMessageSent(const Tp::Message &message, Tp::MessageSendingFlags flags, const QString &sentMessageToken)
+void TextChannelObserver::onMessageSent(const Tp::Message &message, Tp::MessageSendingFlags /* flags */, const QString &sentMessageToken)
 {
     Tp::TextChannelPtr textChannel(qobject_cast<Tp::TextChannel*>(sender()));
     if (textChannel.isNull()) {

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,5 @@ override_dh_install:
 
 override_dh_auto_test:
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
-	#CTEST_OUTPUT_ON_FAILURE=1 make -C obj-$(DEB_HOST_GNU_TYPE) test
-	cd obj-$(DEB_HOST_GNU_TYPE); ctest
+	CTEST_OUTPUT_ON_FAILURE=1 make -j1 -C obj-$(DEB_HOST_GNU_TYPE) test
 endif

--- a/plugins/sqlite/sqlitedatabase.cpp
+++ b/plugins/sqlite/sqlitedatabase.cpp
@@ -37,21 +37,21 @@ Q_DECLARE_OPAQUE_POINTER(sqlite3*)
 Q_DECLARE_METATYPE(sqlite3*)
 
 // custom sqlite function "comparePhoneNumbers" used to compare IDs if necessary
-void comparePhoneNumbers(sqlite3_context *context, int argc, sqlite3_value **argv)
+void comparePhoneNumbers(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
 {
     QString arg1((const char*)sqlite3_value_text(argv[0]));
     QString arg2((const char*)sqlite3_value_text(argv[1]));
     sqlite3_result_int(context, (int)History::PhoneUtils::comparePhoneNumbers(arg1, arg2));
 }
 
-void compareNormalizedPhoneNumbers(sqlite3_context *context, int argc, sqlite3_value **argv)
+void compareNormalizedPhoneNumbers(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
 {
     QString arg1((const char*)sqlite3_value_text(argv[0]));
     QString arg2((const char*)sqlite3_value_text(argv[1]));
     sqlite3_result_int(context, (int)History::PhoneUtils::compareNormalizedPhoneNumbers(arg1, arg2));
 }
 
-void normalizeId(sqlite3_context *context, int argc, sqlite3_value **argv)
+void normalizeId(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
 {
     QString accountId((const char*)sqlite3_value_text(argv[0]));
     QString id((const char*)sqlite3_value_text(argv[1]));
@@ -131,7 +131,7 @@ bool SQLiteDatabase::reopen()
 
     // make sure the database is up-to-date after reopening.
     // this is mainly required for the memory backend used for testing
-    createOrUpdateDatabase();
+    return createOrUpdateDatabase();
 }
 
 QString SQLiteDatabase::dumpSchema() const
@@ -184,7 +184,7 @@ bool SQLiteDatabase::runMultipleStatements(const QStringList &statements, bool u
 }
 
 
-void trace(void *something, const char *query)
+void trace(void* /* something */, const char *query)
 {
     qDebug() << "SQLITE TRACE:" << query;
 }
@@ -454,5 +454,6 @@ bool SQLiteDatabase::convertOfonoGroupChatToRoom()
         queryInsertRoom.clear();
     }
     query.clear();
-}
 
+    return true;
+}

--- a/plugins/sqlite/sqlitedatabase.cpp
+++ b/plugins/sqlite/sqlitedatabase.cpp
@@ -37,22 +37,28 @@ Q_DECLARE_OPAQUE_POINTER(sqlite3*)
 Q_DECLARE_METATYPE(sqlite3*)
 
 // custom sqlite function "comparePhoneNumbers" used to compare IDs if necessary
-void comparePhoneNumbers(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
+void comparePhoneNumbers(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
+    Q_ASSERT(argc >= 2);
+
     QString arg1((const char*)sqlite3_value_text(argv[0]));
     QString arg2((const char*)sqlite3_value_text(argv[1]));
     sqlite3_result_int(context, (int)History::PhoneUtils::comparePhoneNumbers(arg1, arg2));
 }
 
-void compareNormalizedPhoneNumbers(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
+void compareNormalizedPhoneNumbers(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
+    Q_ASSERT(argc >= 2);
+
     QString arg1((const char*)sqlite3_value_text(argv[0]));
     QString arg2((const char*)sqlite3_value_text(argv[1]));
     sqlite3_result_int(context, (int)History::PhoneUtils::compareNormalizedPhoneNumbers(arg1, arg2));
 }
 
-void normalizeId(sqlite3_context *context, int /* argc */, sqlite3_value **argv)
+void normalizeId(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
+    Q_ASSERT(argc >= 2);
+
     QString accountId((const char*)sqlite3_value_text(argv[0]));
     QString id((const char*)sqlite3_value_text(argv[1]));
     QString normalizedId = History::Utils::normalizeId(accountId, id);

--- a/plugins/sqlite/sqlitehistoryeventview.cpp
+++ b/plugins/sqlite/sqlitehistoryeventview.cpp
@@ -31,8 +31,8 @@ SQLiteHistoryEventView::SQLiteHistoryEventView(SQLiteHistoryPlugin *plugin,
                                              History::EventType type,
                                              const History::Sort &sort,
                                              const History::Filter &filter)
-    : History::PluginEventView(), mType(type), mSort(sort), mFilter(filter),
-      mQuery(SQLiteDatabase::instance()->database()), mPageSize(15), mPlugin(plugin), mOffset(0), mValid(true)
+    : History::PluginEventView(),  mPlugin(plugin), mType(type), mSort(sort), mFilter(filter),
+      mQuery(SQLiteDatabase::instance()->database()), mPageSize(15), mOffset(0), mValid(true)
 {
     mTemporaryTable = QString("eventview%1%2").arg(QString::number((qulonglong)this), QDateTime::currentDateTimeUtc().toString("yyyyMMddhhmmsszzz"));
     mQuery.setForwardOnly(true);

--- a/plugins/sqlite/sqlitehistoryeventview.h
+++ b/plugins/sqlite/sqlitehistoryeventview.h
@@ -48,15 +48,15 @@ protected:
 
 
 private:
+    SQLiteHistoryPlugin *mPlugin;
     History::EventType mType;
     History::Sort mSort;
     History::Filter mFilter;
     QSqlQuery mQuery;
     int mPageSize;
-    SQLiteHistoryPlugin *mPlugin;
-    QString mTemporaryTable;
     int mOffset;
     bool mValid;
+    QString mTemporaryTable;
 };
 
 #endif // SQLITEHISTORYEVENTVIEW_H

--- a/plugins/sqlite/sqlitehistoryplugin.cpp
+++ b/plugins/sqlite/sqlitehistoryplugin.cpp
@@ -708,7 +708,7 @@ bool SQLiteHistoryPlugin::updateRoomParticipantsRoles(const QString &accountId, 
     return true;
 }
 
-bool SQLiteHistoryPlugin::updateRoomInfo(const QString &accountId, const QString &threadId, History::EventType type, const QVariantMap &properties, const QStringList &invalidated)
+bool SQLiteHistoryPlugin::updateRoomInfo(const QString &accountId, const QString &threadId, History::EventType type, const QVariantMap &properties, const QStringList& /* invalidated */)
 {
     QSqlQuery query(SQLiteDatabase::instance()->database());
 
@@ -1207,6 +1207,9 @@ QString SQLiteHistoryPlugin::sqlQueryForThreads(History::EventType type, const Q
         table = "voice_events";
         extraFields << "voice_events.duration" << "voice_events.missed" << "voice_events.remoteParticipant";
         break;
+    case History::EventTypeNull:
+        qWarning("SQLiteHistoryPlugin::sqlQueryForThreads: Got EventTypeNull, ignoring this event!");
+        break;
     }
 
     fields << QString("%1.senderId").arg(table)
@@ -1371,6 +1374,9 @@ QList<QVariantMap> SQLiteHistoryPlugin::parseThreadResults(History::EventType ty
             thread[History::FieldRemoteParticipant] = History::ContactMatcher::instance()->contactInfo(accountId, query.value(10).toString(), true);
             threads << thread;
             break;
+        case History::EventTypeNull:
+            qWarning("SQLiteHistoryPlugin::parseThreadResults: Got EventTypeNull, ignoring this event!");
+            break;
         }
     }
 
@@ -1406,6 +1412,9 @@ QString SQLiteHistoryPlugin::sqlQueryForEvents(History::EventType type, const QS
         participantsField = participantsField.arg("voice_events", QString::number(type));
         queryText = QString("SELECT accountId, threadId, eventId, senderId, timestamp, newEvent, %1, "
                             "duration, missed, remoteParticipant FROM voice_events %2 %3").arg(participantsField, modifiedCondition, order);
+        break;
+    case History::EventTypeNull:
+        qWarning("SQLiteHistoryPlugin::sqlQueryForEvents: Got EventTypeNull, ignoring this event!");
         break;
     }
 
@@ -1482,6 +1491,9 @@ QList<QVariantMap> SQLiteHistoryPlugin::parseEventResults(History::EventType typ
             event[History::FieldDuration] = query.value(7).toInt();
             event[History::FieldMissed] = query.value(8);
             event[History::FieldRemoteParticipant] = query.value(9).toString();
+            break;
+        case History::EventTypeNull:
+            qWarning("SQLiteHistoryPlugin::parseEventResults: Got EventTypeNull, ignoring this event!");
             break;
         }
 

--- a/plugins/sqlite/sqlitehistoryplugin.cpp
+++ b/plugins/sqlite/sqlitehistoryplugin.cpp
@@ -1521,6 +1521,7 @@ QString SQLiteHistoryPlugin::filterToString(const History::Filter &filter, QVari
     case History::FilterTypeIntersection:
         filters = History::IntersectionFilter(filter).filters();
         linking = " AND ";
+        // fall through
     case History::FilterTypeUnion:
         if (filter.type() == History::FilterTypeUnion) {
             filters = History::UnionFilter(filter).filters();

--- a/plugins/sqlite/sqlitehistorythreadview.h
+++ b/plugins/sqlite/sqlitehistorythreadview.h
@@ -45,12 +45,12 @@ public:
     bool IsValid() const;
 
 private:
+    SQLiteHistoryPlugin *mPlugin;
     History::EventType mType;
     History::Sort mSort;
     History::Filter mFilter;
-    QSqlQuery mQuery;
     int mPageSize;
-    SQLiteHistoryPlugin *mPlugin;
+    QSqlQuery mQuery;
     QString mTemporaryTable;
     int mOffset;
     bool mValid;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -122,6 +122,7 @@ Event& Event::operator=(const Event &other)
     }
 
     d_ptr = QSharedPointer<EventPrivate>(other.d_ptr->clone());
+    return *this;
 }
 
 /*!

--- a/src/eventview.cpp
+++ b/src/eventview.cpp
@@ -169,6 +169,9 @@ QList<Event> EventView::nextPage()
         case EventTypeVoice:
             event = VoiceEvent::fromProperties(properties);
             break;
+        case EventTypeNull:
+            qWarning("EventView::nextPage(): Got EventTypeNull, ignoring this event!");
+            break;
         }
 
         if (!event.isNull()) {

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -143,6 +143,7 @@ Filter &Filter::operator=(const Filter &other)
     }
 
     d_ptr = QSharedPointer<FilterPrivate>(other.d_ptr->clone());
+    return *this;
 }
 
 QString Filter::filterProperty() const

--- a/src/managerdbus.cpp
+++ b/src/managerdbus.cpp
@@ -261,7 +261,13 @@ Event ManagerDBus::eventFromProperties(const QVariantMap &properties)
         return TextEvent::fromProperties(properties);
     case EventTypeVoice:
         return VoiceEvent::fromProperties(properties);
+    case EventTypeNull:
+        qWarning("ManagerDBus::eventFromProperties: Got EventTypeNull, returning NULL event!");
+        return Event();
     }
+
+    // We should NEVER reach this
+    return Event();
 }
 
 Events ManagerDBus::eventsFromProperties(const QList<QVariantMap> &eventsProperties)
@@ -288,4 +294,3 @@ QList<QVariantMap> ManagerDBus::eventsToProperties(const Events &events)
 
 
 }
-

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -74,23 +74,23 @@ public:
     virtual QList<QVariantMap> eventsForThread(const QVariantMap &thread) = 0;
 
     // Writer part of the plugin
-    virtual QVariantMap createThreadForParticipants(const QString &accountId, EventType type, const QStringList &participants) { return QVariantMap(); }
-    virtual QVariantMap createThreadForProperties(const QString &accountId, EventType type, const QVariantMap &properties) { return QVariantMap(); }
-    virtual bool updateRoomParticipants(const QString &accountId, const QString &threadId, History::EventType type, const QVariantList &participants) { return false; };
-    virtual bool updateRoomParticipantsRoles(const QString &accountId, const QString &threadId, History::EventType type, const QVariantMap &participantsRoles) { return false; };
-    virtual bool updateRoomInfo(const QString &accountId, const QString &threadId, EventType type, const QVariantMap &properties, const QStringList &invalidated = QStringList()) { return false; };
-    virtual bool removeThread(const QVariantMap &thread) { return false; }
-    virtual QVariantMap markThreadAsRead(const QVariantMap &thread) { return QVariantMap(); }
+    virtual QVariantMap createThreadForParticipants(const QString& /* accountId */, EventType /* type */, const QStringList& /* participants */) { return QVariantMap(); }
+    virtual QVariantMap createThreadForProperties(const QString& /* accountId */, EventType /* type */, const QVariantMap& /* properties */) { return QVariantMap(); }
+    virtual bool updateRoomParticipants(const QString& /* accountId */, const QString& /* threadId */, History::EventType /* type */, const QVariantList& /* participants */) { return false; };
+    virtual bool updateRoomParticipantsRoles(const QString& /* accountId */, const QString& /* threadId */, History::EventType /* type */, const QVariantMap& /* participantsRoles */) { return false; };
+    virtual bool updateRoomInfo(const QString& /* accountId */, const QString& /* threadId */, EventType /* type */, const QVariantMap& /* properties */, const QStringList& /* invalidated */ = QStringList()) { return false; };
+    virtual bool removeThread(const QVariantMap& /* thread */) { return false; }
+    virtual QVariantMap markThreadAsRead(const QVariantMap& /* thread */) { return QVariantMap(); }
 
-    virtual EventWriteResult writeTextEvent(const QVariantMap &event) { return EventWriteError; }
-    virtual bool removeTextEvent(const QVariantMap &event) { return false; }
+    virtual EventWriteResult writeTextEvent(const QVariantMap& /* event */) { return EventWriteError; }
+    virtual bool removeTextEvent(const QVariantMap& /* event */) { return false; }
 
-    virtual EventWriteResult writeVoiceEvent(const QVariantMap &event) { return EventWriteError; }
-    virtual bool removeVoiceEvent(const QVariantMap &event) { return false; }
+    virtual EventWriteResult writeVoiceEvent(const QVariantMap& /* event */) { return EventWriteError; }
+    virtual bool removeVoiceEvent(const QVariantMap& /* event */) { return false; }
 
-    virtual bool beginBatchOperation() {}
-    virtual bool endBatchOperation() {}
-    virtual bool rollbackBatchOperation() {}
+    virtual bool beginBatchOperation() { return false; }
+    virtual bool endBatchOperation() { return false; }
+    virtual bool rollbackBatchOperation() { return false; }
 
     // FIXME: this is hackish, but changing it required a broad refactory of HistoryDaemon
     virtual void generateContactCache() {}

--- a/src/texteventattachment.cpp
+++ b/src/texteventattachment.cpp
@@ -83,6 +83,7 @@ TextEventAttachment::~TextEventAttachment()
 TextEventAttachment& TextEventAttachment::operator=(const TextEventAttachment &other)
 {
     d_ptr = QSharedPointer<TextEventAttachmentPrivate>(new TextEventAttachmentPrivate(*other.d_ptr));
+    return *this;
 }
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -286,6 +286,9 @@ Thread Thread::fromProperties(const QVariantMap &properties)
         case EventTypeVoice:
             event = VoiceEvent::fromProperties(properties);
             break;
+        case EventTypeNull:
+            qWarning("Thread::fromProperties: Got EventTypeNull, using NULL event!");
+            break;
     }
     return Thread(accountId, threadId, type, participants, timestamp, event, count, unreadCount, groupedThreads, chatType, chatRoomInfo);
 }

--- a/src/thread_p.h
+++ b/src/thread_p.h
@@ -49,8 +49,8 @@ public:
 
     QString accountId;
     QString threadId;
-    Participants participants;
     EventType type;
+    Participants participants;
     QDateTime timestamp;
     Event lastEvent;
     int count;

--- a/src/types.h
+++ b/src/types.h
@@ -67,7 +67,8 @@ enum MessageStatus
     MessageStatusRead,
     MessageStatusDeleted,
     MessageStatusPending, // pending attachment download
-    MessageStatusDraft
+    MessageStatusDraft,
+    _MessageStatusPadding
 };
 
 enum MessageType
@@ -100,7 +101,10 @@ enum ChatType
 {
     ChatTypeNone = 0,
     ChatTypeContact = 1,
-    ChatTypeRoom = 2
+    ChatTypeRoom = 2,
+    ChatTypeGroup = 3,
+    ChatTypeList = 4,
+    _ChatTypePadding = 5
 };
 
 // FIXME (boiko): I think this needs to be changed to a simple enum and not flags,
@@ -134,6 +138,12 @@ enum EventWriteResult {
     EventWriteModified,
     EventWriteError
 };
+
+// Since these might not get used in evey file that
+// includes this file, lets ignore the unused-variable
+// warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 
 // dbus service, object path and interface
 static const char* DBusService = "com.canonical.HistoryService";
@@ -225,6 +235,8 @@ static const char* FieldIdentifier = "identifier";
 static const char* FieldDetailProperties = "detailProperties";
 static const char* FieldParticipantState = "state";
 static const char* FieldParticipantRoles = "roles";
+
+#pragma GCC diagnostic pop
 
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -136,7 +136,8 @@ enum ParticipantRoles
 enum EventWriteResult {
     EventWriteCreated,
     EventWriteModified,
-    EventWriteError
+    EventWriteError,
+    EventWriteNone
 };
 
 // Since these might not get used in evey file that

--- a/tests/common/mock/callchannel.cpp
+++ b/tests/common/mock/callchannel.cpp
@@ -59,7 +59,7 @@ MockCallChannel::MockCallChannel(MockConnection *conn, QString phoneNumber, QStr
     QTimer::singleShot(0, this, SLOT(init()));
 }
 
-void MockCallChannel::onHangup(uint reason, const QString &detailedReason, const QString &message, Tp::DBusError *error)
+void MockCallChannel::onHangup(uint /* reason */, const QString& /* detailedReason */, const QString& /* message */, Tp::DBusError* /* error */)
 {
     // TODO: use the parameters sent by telepathy
     mRequestedHangup = true;
@@ -114,7 +114,7 @@ void MockCallChannel::onOfonoMuteChanged(bool mute)
     mMuteIface->setMuteState(state);
 }
 
-void MockCallChannel::onHoldStateChanged(const Tp::LocalHoldState &state, const Tp::LocalHoldStateReason &reason, Tp::DBusError *error)
+void MockCallChannel::onHoldStateChanged(const Tp::LocalHoldState &state, const Tp::LocalHoldStateReason& /* reason */, Tp::DBusError* /* error */)
 {
     if (state == Tp::LocalHoldStateHeld && mState == "active") {
         setCallState("held");
@@ -123,7 +123,7 @@ void MockCallChannel::onHoldStateChanged(const Tp::LocalHoldState &state, const 
     }
 }
 
-void MockCallChannel::onMuteStateChanged(const Tp::LocalMuteState &state, Tp::DBusError *error)
+void MockCallChannel::onMuteStateChanged(const Tp::LocalMuteState &state, Tp::DBusError* /* error */)
 {
 #if 0
     FIXME: reimplement
@@ -132,10 +132,12 @@ void MockCallChannel::onMuteStateChanged(const Tp::LocalMuteState &state, Tp::DB
     } else if (state == Tp::LocalMuteStateUnmuted) {
         mConnection->callVolume()->setMuted(false);
     }
+#else
+    Q_UNUSED(state);
 #endif
 }
 
-void MockCallChannel::onDTMFStartTone(uchar event, Tp::DBusError *error)
+void MockCallChannel::onDTMFStartTone(uchar event, Tp::DBusError* /* error */)
 {
     QString finalString;
     if (event == 10) {
@@ -149,11 +151,11 @@ void MockCallChannel::onDTMFStartTone(uchar event, Tp::DBusError *error)
     qDebug() << "start tone" << finalString;
 }
 
-void MockCallChannel::onDTMFStopTone(Tp::DBusError *error)
+void MockCallChannel::onDTMFStopTone(Tp::DBusError* /* error */)
 {
 }
 
-void MockCallChannel::onSplit(Tp::DBusError *error)
+void MockCallChannel::onSplit(Tp::DBusError* /* error */)
 {
     Q_EMIT splitted();
 }

--- a/tests/common/mock/callchannel.h
+++ b/tests/common/mock/callchannel.h
@@ -63,14 +63,14 @@ Q_SIGNALS:
     void splitted();
 
 private:
-    QString mObjPath;
-    QString mState;
     bool mIncoming;
     bool mRequestedHangup;
-    Tp::BaseChannelPtr mBaseChannel;
-    QString mPhoneNumber;
     MockConnection *mConnection;
+    QString mPhoneNumber;
     uint mTargetHandle;
+    QString mState;
+    QString mObjPath;
+    Tp::BaseChannelPtr mBaseChannel;
     Tp::BaseChannelHoldInterfacePtr mHoldIface;
     Tp::BaseCallMuteInterfacePtr mMuteIface;
     Tp::BaseChannelSplittableInterfacePtr mSplittableIface;

--- a/tests/common/mock/conferencecallchannel.cpp
+++ b/tests/common/mock/conferencecallchannel.cpp
@@ -22,7 +22,7 @@
 #include "callchannel.h"
 
 
-MockConferenceCallChannel::MockConferenceCallChannel(MockConnection *conn, QList<QDBusObjectPath> callChannels, QObject *parent):
+MockConferenceCallChannel::MockConferenceCallChannel(MockConnection *conn, QList<QDBusObjectPath> callChannels, QObject* /* parent */):
     mRequestedHangup(false),
     mConnection(conn),
     mDtmfLock(false),
@@ -89,7 +89,7 @@ Tp::BaseChannelPtr MockConferenceCallChannel::baseChannel()
     return mBaseChannel;
 }
 
-void MockConferenceCallChannel::onMerge(const QDBusObjectPath &channel, Tp::DBusError *error)
+void MockConferenceCallChannel::onMerge(const QDBusObjectPath &channel, Tp::DBusError* /* error */)
 {
     if (!mCallChannels.contains(channel)) {
         mCallChannels << channel;
@@ -120,13 +120,13 @@ void MockConferenceCallChannel::onChannelSplitted(const QDBusObjectPath &path)
     }
 }
 
-void MockConferenceCallChannel::onTurnOnSpeaker(bool active, Tp::DBusError *error)
+void MockConferenceCallChannel::onTurnOnSpeaker(bool /* active */, Tp::DBusError* /* error */)
 {
     //mConnection->setSpeakerMode(active);
     // FIXME: reimplement
 }
 
-void MockConferenceCallChannel::onHangup(uint reason, const QString &detailedReason, const QString &message, Tp::DBusError *error)
+void MockConferenceCallChannel::onHangup(uint reason, const QString& /* detailedReason */, const QString &message, Tp::DBusError* /* error */)
 {
     //FIXME: reimplement
     Tp::CallStateReason theReason;
@@ -186,7 +186,7 @@ void MockConferenceCallChannel::setConferenceActive(bool active)
     }
 }
 
-void MockConferenceCallChannel::onHoldStateChanged(const Tp::LocalHoldState &state, const Tp::LocalHoldStateReason &reason, Tp::DBusError *error)
+void MockConferenceCallChannel::onHoldStateChanged(const Tp::LocalHoldState& /* state */, const Tp::LocalHoldStateReason& /* reason */, Tp::DBusError* /* error */)
 {
     /*if (state == Tp::LocalHoldStateHeld && mHoldIface->getHoldState() == Tp::LocalHoldStateUnheld) {
         mConnection->voiceCallManager()->swapCalls();
@@ -197,7 +197,7 @@ void MockConferenceCallChannel::onHoldStateChanged(const Tp::LocalHoldState &sta
     // FIXME: reimplement
 }
 
-void MockConferenceCallChannel::onMuteStateChanged(const Tp::LocalMuteState &state, Tp::DBusError *error)
+void MockConferenceCallChannel::onMuteStateChanged(const Tp::LocalMuteState& /* state */, Tp::DBusError* /* error */)
 {
     /*if (state == Tp::LocalMuteStateMuted) {
         mConnection->callVolume()->setMuted(true);
@@ -234,7 +234,7 @@ void MockConferenceCallChannel::onDtmfComplete(bool success)
     }
 }
 
-void MockConferenceCallChannel::onDTMFStartTone(uchar event, Tp::DBusError *error)
+void MockConferenceCallChannel::onDTMFStartTone(uchar event, Tp::DBusError* /* error */)
 {
     QString finalString;
     if (event == 10) {
@@ -256,7 +256,7 @@ void MockConferenceCallChannel::onDTMFStartTone(uchar event, Tp::DBusError *erro
     sendNextDtmf();
 }
 
-void MockConferenceCallChannel::onDTMFStopTone(Tp::DBusError *error)
+void MockConferenceCallChannel::onDTMFStopTone(Tp::DBusError* /* error */)
 {
 }
 

--- a/tests/common/mock/conferencecallchannel.h
+++ b/tests/common/mock/conferencecallchannel.h
@@ -63,12 +63,13 @@ private Q_SLOTS:
     void onChannelSplitted(const QDBusObjectPath &path);
 
 private:
+    bool mRequestedHangup;
+    MockConnection *mConnection;
+    bool mDtmfLock;
+    QList<QDBusObjectPath> mCallChannels;
     QString mObjPath;
     QString mPreviousState;
     bool mIncoming;
-    bool mRequestedHangup;
-    MockConnection *mConnection;
-    QList<QDBusObjectPath> mCallChannels;
     Tp::BaseChannelPtr mBaseChannel;
     Tp::BaseChannelHoldInterfacePtr mHoldIface;
     Tp::BaseChannelConferenceInterfacePtr mConferenceIface;
@@ -77,7 +78,6 @@ private:
     BaseChannelSpeakerInterfacePtr mSpeakerIface;
     Tp::BaseChannelCallTypePtr mCallChannel;
     Tp::BaseCallContentDTMFInterfacePtr mDTMFIface;
-    bool mDtmfLock;
     QStringList mDtmfPendingStrings;
 };
 

--- a/tests/common/mock/connection.cpp
+++ b/tests/common/mock/connection.cpp
@@ -298,7 +298,7 @@ QStringList MockConnection::inspectHandles(uint handleType, const Tp::UIntList& 
     return identifiers;
 }
 
-void MockConnection::connect(Tp::DBusError *error) {
+void MockConnection::connect(Tp::DBusError* /* error */) {
     qDebug() << "MockConnection::connect";
     setStatus(Tp::ConnectionStatusConnected, Tp::ConnectionStatusReasonRequested);
 }
@@ -350,6 +350,7 @@ Tp::BaseChannelPtr MockConnection::createTextChannel(uint targetHandleType,
     }
 
     // FIXME: test flash messages
+    Q_UNUSED(flash);
     MockTextChannel *channel = new MockTextChannel(this, recipients, targetHandle);
     QObject::connect(channel, SIGNAL(messageRead(QString)), SLOT(onMessageRead(QString)));
     QObject::connect(channel, SIGNAL(destroyed()), SLOT(onTextChannelClosed()));
@@ -587,7 +588,7 @@ QString MockConnection::placeCall(const QVariantMap &properties)
     return channel->objectPath();
 }
 
-QStringList MockConnection::emergencyNumbers(Tp::DBusError *error)
+QStringList MockConnection::emergencyNumbers(Tp::DBusError* /* error */)
 {
     return mEmergencyNumbers;
 }
@@ -598,7 +599,7 @@ void MockConnection::setEmergencyNumbers(const QStringList &emergencyNumbers)
     emergencyModeIface->setEmergencyNumbers(emergencyNumbers);
 }
 
-bool MockConnection::voicemailIndicator(Tp::DBusError *error)
+bool MockConnection::voicemailIndicator(Tp::DBusError* /* error */)
 {
     return mVoicemailIndicator;
 }
@@ -609,7 +610,7 @@ void MockConnection::setVoicemailIndicator(bool visible)
     voicemailIface->setVoicemailIndicator(visible);
 }
 
-QString MockConnection::voicemailNumber(Tp::DBusError *error)
+QString MockConnection::voicemailNumber(Tp::DBusError* /* error */)
 {
     return mVoicemailNumber;
 }
@@ -620,7 +621,7 @@ void MockConnection::setVoicemailNumber(const QString &number)
     voicemailIface->setVoicemailNumber(mVoicemailNumber);
 }
 
-uint MockConnection::voicemailCount(Tp::DBusError *error)
+uint MockConnection::voicemailCount(Tp::DBusError* /* error */)
 {
     return mVoicemailCount;
 }
@@ -631,17 +632,17 @@ void MockConnection::setVoicemailCount(int count)
     voicemailIface->setVoicemailCount(mVoicemailCount);
 }
 
-void MockConnection::USSDInitiate(const QString &command, Tp::DBusError *error)
+void MockConnection::USSDInitiate(const QString& /* command */, Tp::DBusError* /* error */)
 {
     // FIXME: implement
 }
 
-void MockConnection::USSDRespond(const QString &reply, Tp::DBusError *error)
+void MockConnection::USSDRespond(const QString& /* reply */, Tp::DBusError* /* error */)
 {
     // FIXME: implement
 }
 
-void MockConnection::USSDCancel(Tp::DBusError *error)
+void MockConnection::USSDCancel(Tp::DBusError* /* error */)
 {
     // FIXME: implement
 }

--- a/tests/common/mock/connection.h
+++ b/tests/common/mock/connection.h
@@ -150,8 +150,8 @@ private:
     MockConferenceCallChannel *mConferenceCall;
 
     QStringList mEmergencyNumbers;
-    int mVoicemailCount;
     bool mVoicemailIndicator;
+    int mVoicemailCount;
     QString mVoicemailNumber;
 };
 

--- a/tests/common/mock/emergencymodeiface.cpp
+++ b/tests/common/mock/emergencymodeiface.cpp
@@ -120,7 +120,7 @@ ConnectionInterfaceEmergencyModeAdaptor::~ConnectionInterfaceEmergencyModeAdapto
 
 QStringList ConnectionInterfaceEmergencyModeAdaptor::EmergencyNumbers(const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("emergencyNumbers(ConnectionInterfaceEmergencyModeAdaptor::EmergencyNumbersContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("emergencyNumbers(ConnectionInterfaceEmergencyModeAdaptor::EmergencyNumbersContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return QStringList();
     }

--- a/tests/common/mock/speakeriface.cpp
+++ b/tests/common/mock/speakeriface.cpp
@@ -111,7 +111,7 @@ ChannelInterfaceSpeakerAdaptor::~ChannelInterfaceSpeakerAdaptor()
 
 void ChannelInterfaceSpeakerAdaptor::turnOnSpeaker(bool active, const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("turnOnSpeaker(bool,ChannelInterfaceSpeakerAdaptor::turnOnSpeakerContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("turnOnSpeaker(bool,ChannelInterfaceSpeakerAdaptor::turnOnSpeakerContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return;
     }
@@ -128,4 +128,3 @@ bool ChannelInterfaceSpeakerAdaptor::SpeakerMode() const
 {
     return qvariant_cast< bool >(adaptee()->property("speakerMode"));
 }
-

--- a/tests/common/mock/textchannel.cpp
+++ b/tests/common/mock/textchannel.cpp
@@ -101,7 +101,7 @@ void MockTextChannel::messageAcknowledged(const QString &id)
     Q_EMIT messageRead(id);
 }
 
-QString MockTextChannel::sendMessage(const Tp::MessagePartList& message, uint flags, Tp::DBusError* error)
+QString MockTextChannel::sendMessage(const Tp::MessagePartList& message, uint /* flags */, Tp::DBusError* /* error */)
 {
     Tp::MessagePart header = message.at(0);
     Tp::MessagePart body = message.at(1);
@@ -248,12 +248,12 @@ Tp::UIntList MockTextChannel::members()
     return mMembers;
 }
 
-void MockTextChannel::onAddMembers(const Tp::UIntList &handles, const QString &message, Tp::DBusError *error)
+void MockTextChannel::onAddMembers(const Tp::UIntList &handles, const QString& /* message */, Tp::DBusError *error)
 {
     addMembers(mConnection->inspectHandles(Tp::HandleTypeContact, handles, error));
 }
 
-void MockTextChannel::onRemoveMembers(const Tp::UIntList &handles, const QString &message, uint reason, Tp::DBusError *error)
+void MockTextChannel::onRemoveMembers(const Tp::UIntList &handles, const QString& /* message */, uint /* reason */, Tp::DBusError *error)
 {
     Q_FOREACH(uint handle, handles) {
         Q_FOREACH(const QString &recipient, mConnection->inspectHandles(Tp::HandleTypeContact, Tp::UIntList() << handle, error)) {

--- a/tests/common/mock/textchannel.h
+++ b/tests/common/mock/textchannel.h
@@ -57,14 +57,14 @@ Q_SIGNALS:
 
 private:
     ~MockTextChannel();
-    Tp::BaseChannelPtr mBaseChannel;
-    QStringList mRecipients;
     MockConnection *mConnection;
+    QStringList mRecipients;
     uint mTargetHandle;
+    uint mMessageCounter;
+    Tp::BaseChannelPtr mBaseChannel;
     Tp::BaseChannelMessagesInterfacePtr mMessagesIface;
     Tp::BaseChannelGroupInterfacePtr mGroupIface;
     Tp::BaseChannelTextTypePtr mTextChannel;
-    uint mMessageCounter;
     Tp::UIntList mMembers;
 };
 

--- a/tests/common/mock/ussdiface.cpp
+++ b/tests/common/mock/ussdiface.cpp
@@ -257,7 +257,7 @@ ConnectionInterfaceUSSDAdaptor::~ConnectionInterfaceUSSDAdaptor()
 
 void ConnectionInterfaceUSSDAdaptor::Initiate(const QString &command, const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("initiate(const QString &,ConnectionInterfaceUSSDAdaptor::InitiateContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("initiate(const QString &,ConnectionInterfaceUSSDAdaptor::InitiateContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return;
     }
@@ -272,7 +272,7 @@ void ConnectionInterfaceUSSDAdaptor::Initiate(const QString &command, const QDBu
 
 void ConnectionInterfaceUSSDAdaptor::Respond(const QString &reply, const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("respond(QConnectionInterfaceUSSDAdaptor::RespondContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("respond(QConnectionInterfaceUSSDAdaptor::RespondContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return;
     }
@@ -287,7 +287,7 @@ void ConnectionInterfaceUSSDAdaptor::Respond(const QString &reply, const QDBusMe
 
 void ConnectionInterfaceUSSDAdaptor::Cancel(const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("cancel(ConnectionInterfaceUSSDAdaptor::CancelContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("cancel(ConnectionInterfaceUSSDAdaptor::CancelContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return;
     }
@@ -309,4 +309,3 @@ QString ConnectionInterfaceUSSDAdaptor::State() const
 {
     return qvariant_cast< QString >(adaptee()->property("state"));
 }
-

--- a/tests/common/mock/voicemailiface.cpp
+++ b/tests/common/mock/voicemailiface.cpp
@@ -160,7 +160,7 @@ ConnectionInterfaceVoicemailAdaptor::~ConnectionInterfaceVoicemailAdaptor()
 
 bool ConnectionInterfaceVoicemailAdaptor::VoicemailIndicator(const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("voicemailIndicator(ConnectionInterfaceVoicemailAdaptor::VoicemailIndicatorContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("voicemailIndicator(ConnectionInterfaceVoicemailAdaptor::VoicemailIndicatorContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return bool();
     }
@@ -174,7 +174,7 @@ bool ConnectionInterfaceVoicemailAdaptor::VoicemailIndicator(const QDBusMessage&
 
 QString ConnectionInterfaceVoicemailAdaptor::VoicemailNumber(const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("voicemailNumber(ConnectionInterfaceVoicemailAdaptor::VoicemailNumberContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("voicemailNumber(ConnectionInterfaceVoicemailAdaptor::VoicemailNumberContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return QString();
     }
@@ -188,7 +188,7 @@ QString ConnectionInterfaceVoicemailAdaptor::VoicemailNumber(const QDBusMessage&
 
 uint ConnectionInterfaceVoicemailAdaptor::VoicemailCount(const QDBusMessage& dbusMessage)
 {
-    if (!adaptee()->metaObject()->indexOfMethod("voicemailCount(ConnectionInterfaceVoicemailAdaptor::VoicemailCountContextPtr)") == -1) {
+    if (!adaptee()->metaObject()->indexOfMethod("voicemailCount(ConnectionInterfaceVoicemailAdaptor::VoicemailCountContextPtr)")) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return uint();
     }
@@ -199,4 +199,3 @@ uint ConnectionInterfaceVoicemailAdaptor::VoicemailCount(const QDBusMessage& dbu
         Q_ARG(ConnectionInterfaceVoicemailAdaptor::VoicemailCountContextPtr, ctx));
     return uint();
 }
-

--- a/tests/common/mockcontroller.h
+++ b/tests/common/mockcontroller.h
@@ -63,9 +63,9 @@ public Q_SLOTS:
     QString serial();
 
 private:
-    QDBusInterface mMockInterface;
     QString mProtocol;
     QString mMockObject;
+    QDBusInterface mMockInterface;
 };
 
 #endif // MOCKCONTROLLER_H

--- a/tests/daemon/approver.cpp
+++ b/tests/daemon/approver.cpp
@@ -171,9 +171,7 @@ Tp::ChannelDispatchOperationPtr Approver::dispatchOperation(Tp::PendingOperation
     return Tp::ChannelDispatchOperationPtr();
 }
 
-void Approver::onChannelReady(Tp::PendingOperation *op)
+void Approver::onChannelReady(Tp::PendingOperation* /* op */)
 {
     Q_EMIT newCall();
 }
-
-

--- a/tests/libhistoryservice/ThreadTest.cpp
+++ b/tests/libhistoryservice/ThreadTest.cpp
@@ -100,6 +100,8 @@ void ThreadTest::testCreateNewThread()
         event = History::VoiceEvent(accountId, threadId, QString("eventId%1").arg(QString::number(qrand() % 1024)),
                                     participants[0], QDateTime::currentDateTime(), false, false, QTime(1,2,3));
         break;
+    case History::EventTypeNull:
+        break;
     }
 
     History::Thread threadItem(accountId, threadId, type, participantsFromIdentifiers(accountId, participants), event.timestamp(), event, count, unreadCount);
@@ -157,6 +159,8 @@ void ThreadTest::testFromProperties()
     case History::EventTypeVoice:
         event = History::VoiceEvent(accountId, threadId, QString("eventId%1").arg(QString::number(qrand() % 1024)),
                                     participants[0], QDateTime::currentDateTime(), false, false, QTime(1,2,3));
+        break;
+    case History::EventTypeNull:
         break;
     }
 
@@ -228,6 +232,8 @@ void ThreadTest::testProperties()
     case History::EventTypeVoice:
         event = History::VoiceEvent(accountId, threadId, QString("eventId%1").arg(QString::number(qrand() % 1024)),
                                     participants[0], QDateTime::currentDateTime(), false, false, QTime(1,2,3));
+        break;
+    case History::EventTypeNull:
         break;
     }
 

--- a/tests/plugins/sqlite/SqlitePluginTest.cpp
+++ b/tests/plugins/sqlite/SqlitePluginTest.cpp
@@ -686,6 +686,8 @@ void SqlitePluginTest::testGetSingleEvent()
     case History::EventTypeVoice:
         QCOMPARE(mPlugin->writeVoiceEvent(event), History::EventWriteCreated);
         break;
+    case History::EventTypeNull:
+        break;
     }
 
     QVariantMap retrievedEvent = mPlugin->getSingleEvent(type, event[History::FieldAccountId].toString(),
@@ -708,6 +710,8 @@ void SqlitePluginTest::testGetSingleEvent()
     case History::EventTypeVoice:
         QCOMPARE(retrievedEvent[History::FieldMissed], event[History::FieldMissed]);
         QCOMPARE(retrievedEvent[History::FieldDuration], event[History::FieldDuration]);
+        break;
+    case History::EventTypeNull:
         break;
     }
 }
@@ -820,4 +824,3 @@ void SqlitePluginTest::testEscapeFilterValue()
 
 QTEST_MAIN(SqlitePluginTest)
 #include "SqlitePluginTest.moc"
-

--- a/tools/reader/main.cpp
+++ b/tools/reader/main.cpp
@@ -45,6 +45,9 @@ void printEvent(const History::Event &event)
         voiceEvent = event;
         extraInfo = QString("missed: %1\n      duration: %2").arg(voiceEvent.missed() ? "yes" : "no", voiceEvent.duration().toString());
         break;
+    case History::EventTypeNull:
+        extraInfo = QString("Null event");
+        break;
     }
 
     qDebug() << qPrintable(QString("    * Event: accountId: %1\n      threadId: %2\n      eventId: %3\n      senderId: %4\n      timestamp: %5\n      newEvent: %6")
@@ -62,6 +65,9 @@ void printThread(const History::Thread &thread)
         break;
     case History::EventTypeVoice:
         type = "Voice";
+        break;
+    case History::EventTypeNull:
+        type = "Null";
         break;
     }
 


### PR DESCRIPTION
This cleans up the code to a stricter and better quality code, this should also fix some of the random crashes that I have seen, these crashes happen when history service hits end of a function without the function returning anything. This would have been completely avoided if -Wall -Werror -Wextra has been enabled. 

Fixes: https://github.com/ubports/history-service/issues/29