### PR TITLE
Failed MMS redownload

### DIFF
--- a/daemon/historydaemon.cpp
+++ b/daemon/historydaemon.cpp
@@ -1022,6 +1022,7 @@ void HistoryDaemon::updateRoomProperties(const QString &accountId, const QString
 
 void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, const Tp::ReceivedMessage &message)
 {
+    qDebug() << "jezek - HistoryDaemon::onMessageReceived";
     QString eventId;
     QString senderId;
 
@@ -1103,6 +1104,14 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
         Q_FOREACH(const Tp::MessagePart &part, message.parts()) {
             // ignore the header part
             if (part["content-type"].variant().toString().isEmpty()) {
+                qDebug() << "jezek - part[x-ubports-error].variant(): " << part["x-ubports-error"].variant();
+                qDebug() << "jezek - part[x-ubports-error].variant().isNull(): " << part["x-ubports-error"].variant().isNull();
+                qDebug() << "jezek - part[x-ubports-error].variant().toString(): " << part["x-ubports-error"].variant().toString();
+                // But first check the header if the message contains an error.
+                if (!part["x-ubports-error"].variant().toString().isEmpty()) {
+                    qDebug() << "jezek - Message header has an non-empty x-ubports-error field: " << part["x-ubports-error"].variant().toString();
+                    //status = History::MessageStatusTemporarilyFailed;
+                }
                 continue;
             }
             mmsStoragePath = dir.absoluteFilePath(QString("attachments/%1/%2/%3/").
@@ -1149,8 +1158,10 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
     writeEvents(QList<QVariantMap>() << event, properties);
 
     // if this messages supersedes another one, remove the original message
+    qDebug() << "jezek - supersededToken.isEmpty(): " << message.supersededToken().isEmpty();
     if (!message.supersededToken().isEmpty()) {
         event[History::FieldEventId] = message.supersededToken();
+        qDebug() << "jezek - remove event: " << event;
         removeEvents(QList<QVariantMap>() << event);
     }
 }

--- a/daemon/historydaemon.cpp
+++ b/daemon/historydaemon.cpp
@@ -1022,10 +1022,6 @@ void HistoryDaemon::updateRoomProperties(const QString &accountId, const QString
 
 void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, const Tp::ReceivedMessage &message)
 {
-    qDebug() << "jezek - HistoryDaemon::onMessageReceived";
-    qDebug() << "jezek - message.messageType(): " << message.messageType();
-    qDebug() << "jezek - message.deliveryDetails().isError(): " << message.deliveryDetails().isError();
-    qDebug() << "jezek - message.header()[delivery-status].variant(): " << message.header()["delivery-status"].variant();
     QString eventId;
     QString senderId;
 
@@ -1136,7 +1132,6 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
 
     QString text = message.text();
     if (message.deliveryDetails().isError()) {
-      qDebug() << "jezek - Message is an delivery error message: " << message.deliveryDetails().debugMessage();
       status = fromTelepathyDeliveryStatus(message.deliveryDetails().status());
       text = message.deliveryDetails().debugMessage();
     }
@@ -1160,10 +1155,8 @@ void HistoryDaemon::onMessageReceived(const Tp::TextChannelPtr textChannel, cons
     writeEvents(QList<QVariantMap>() << event, properties);
 
     // if this messages supersedes another one, remove the original message
-    qDebug() << "jezek - supersededToken.isEmpty(): " << message.supersededToken().isEmpty();
     if (!message.supersededToken().isEmpty()) {
         event[History::FieldEventId] = message.supersededToken();
-        qDebug() << "jezek - remove event: " << event;
         removeEvents(QList<QVariantMap>() << event);
     }
 }


### PR DESCRIPTION
This PR has been moved to [gitlab](https://gitlab.com/ubports/core/history-service/-/merge_requests/8)
-----
If you have something to say, make it there. This PR is here only for history purposes and should be closed.
_____

On incoming download error message (indicated by headers), fill status and message text acordingly.
The message text is a json structure, with details about error, expiry time, etc.

Note: This PR is accompanied by ubports/nuntium#8, ubports/telepathy-ofono#20, ubports/telephony-service#20 and ubports/messaging-app#260
Note: After building and deploying to phone with crossbuilder phone needs to be restarted for changes to apply.