### PR TITLE
don't update sentTime column on db upgrade.

### DIFF
--- a/plugins/sqlite/schema/v19.sql
+++ b/plugins/sqlite/schema/v19.sql
@@ -1,2 +1,1 @@
 ALTER TABLE text_events ADD COLUMN sentTime datetime;
-UPDATE text_events SET sentTime = timestamp;

--- a/src/textevent.cpp
+++ b/src/textevent.cpp
@@ -249,6 +249,11 @@ Event TextEvent::fromProperties(const QVariantMap &properties)
         }
     }
 
+    // sentTime may be empty
+    if (!sentTime.isValid()) {
+        sentTime = timestamp;
+    }
+
     // and finally create the event
     event = TextEvent(accountId, threadId, eventId, senderId, timestamp, sentTime, newEvent,
                       message, messageType, messageStatus, readTimestamp, subject, informationType, attachments, participants);


### PR DESCRIPTION
The upgrade script v19.sql was updating sentTime column in bulk: "UPDATE text_events SET sentTime = timestamp;"
As text_events have triggers attached to it. If > 5000 entries, it makes the script hang and a timeout occurs that makes history daemon stopped.

the work around is to not update each row at once but ensure that sentTime is always here when fetching/writing

fixes https://github.com/ubports/messaging-app/issues/288 